### PR TITLE
turn off stacktrace: When the registry starts up it will complain, wi…

### DIFF
--- a/eureka-server1.properties
+++ b/eureka-server1.properties
@@ -1,7 +1,11 @@
 spring.application.name=eureka-server1
 ##eureka.client.serviceUrl.defaultZone=http://127.0.0.1:8761/eureka/
 eureka.client.serviceUrl.defaultZone=http://localhost:8761/eureka/
-eureka.client.registerWithEureka=false
-eureka.client.fetchRegistry=false
+
+eureka.client.register-with-eureka=false
+eureka.client.fetch-registry=false
+
+logging.level.com.netflix.eureka=OFF
+logging.level.com.netflix.discovery=OFF
  
 


### PR DESCRIPTION
…th a stacktrace, that there are no replica nodes for the registry to connect to. In a production environment, you will want more than one instance of the registry. For our simple purposes, however, it sufficies to disable the relevant logging.